### PR TITLE
Fix healthcheck for openresty ≠ nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     build:
       context: https://github.com/openimis/openimis-gateway_dkr.git#${GW_BRANCH:-develop}
     healthcheck:
-      test: service nginx status || exit 1
+      test: curl --fail http://localhost || exit 1
       interval: 10s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
With the healthcheck, the gateway was starting but failing the healthcheck.
I tested this one with a full cleanup of Docker on Linux.