### PR TITLE
OTC-748 Added support for custom site root for backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,6 @@ HTTP_PORT=80
 # https port for openimis
 HTTPS_PORT=443
 
-
 DB_PASSWORD=IMISuserP@s
 DB_USER=IMISuser
 DB_NAME=IMIS
@@ -24,6 +23,9 @@ DB_PORT=5432
 DB_ENGINE=django.db.backends.postgresql
 #DB_ENGINE=mssql
 #ACCEPT_EULA= <y if you accept MS EULA >
+GATEWAY_PORT_S=443
+# site root for backend
+SITE_ROOT=api
 
 # github branches to use
 # Database, you can use develop branch too
@@ -42,10 +44,14 @@ RESTAPI_BRANCH=main
 # rest API flavours
 RESTAPI_BUILD_FLAVOR=Release
 
-
-
-#one-liner json config for the BE (to override the openimis.json from the BE assembly)
-#OPENIMIS_BE_CONF_JSON= 
-
 #one-liner json config for the FE (to override the openimis.json from the FE assembly)
-#OPENIMIS_FE_CONF_JSON= 
+#OPENIMIS_FE_CONF_JSON=
+#one-liner json config for the FE (to overright the openimis.json from the FE assembly)
+#OPENIMIS_FE_CONF_JSON=
+
+# django log level
+DJANGO_LOG_LEVEL=WARNING
+# django log handler (currently: degub-log (default), db-queries, console)
+DJANGO_LOG_HANDLER=debug-log
+# should the database be migrated at every container startup
+DJANGO_MIGRATE=True

--- a/.env.example
+++ b/.env.example
@@ -53,5 +53,5 @@ RESTAPI_BUILD_FLAVOR=Release
 DJANGO_LOG_LEVEL=WARNING
 # django log handler (currently: degub-log (default), db-queries, console)
 DJANGO_LOG_HANDLER=debug-log
-# should the database be migrated at every container startup
+# should the database be migrated at every container startup. Will be done anyway if $SITE_ROOT=api
 DJANGO_MIGRATE=True

--- a/docker-compose-mssql.yml
+++ b/docker-compose-mssql.yml
@@ -27,6 +27,7 @@ services:
     networks:
       openimis-net:
         ipv4_address: 172.20.${IP_SUB:-20}.99
+
   backend:
     container_name: ${PROJECT_NAME:-openimis}-backend
     build:
@@ -44,10 +45,13 @@ services:
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_ENGINE=${DB_ENGINE:-mssql}
-      - SITE_ROOT=api
+      - SITE_ROOT=${SITE_ROOT:-api}
       - SITE_URL=${NEW_OPENIMIS_HOST}
       - CELERY_BROKER_URL=amqp://rabbitmq
       - PHOTO_ROOT_PATH=images/insurees
+      - DJANGO_LOG_LEVEL=${DJANGO_LOG_LEVEL}
+      - DJANGO_LOG_HANDLER=${DJANGO_LOG_HANDLER}
+      - DJANGO_MIGRATE=${DJANGO_MIGRATE}
     depends_on:
       db:
         condition: service_healthy
@@ -65,7 +69,7 @@ services:
     command: serve -s build
     environment:
       - PORT=5000
-      - REACT_APP_API_URL=/api
+      - REACT_APP_API_URL=${SITE_ROOT:-api}
       - PUBLIC_URL=/front
       - NEW_OPENIMIS_HOST=${NEW_OPENIMIS_HOST}
       - OPENIMIS_CONF_JSON=${OPENIMIS_FE_CONF_JSON}
@@ -73,6 +77,7 @@ services:
     networks:
       openimis-net:
         ipv4_address: 172.20.${IP_SUB:-20}.13
+
   gateway:
     container_name: ${PROJECT_NAME:-openimis}-gateway
     build:
@@ -96,6 +101,7 @@ services:
     depends_on:
       - backend
       - frontend
+
   worker:
     container_name: ${PROJECT_NAME:-openimis}-worker
     image: openimis/backend:${PROJECT_NAME:-local}
@@ -109,6 +115,7 @@ services:
     networks:
       openimis-net:
          ipv4_address: 172.20.${IP_SUB:-20}.15
+
   rabbitmq:
     container_name: ${PROJECT_NAME:-openimis}-rabbitmq
     image: rabbitmq:3-management
@@ -116,6 +123,7 @@ services:
     networks:
       openimis-net:
          ipv4_address: 172.20.${IP_SUB:-20}.16
+
   restapi:
     container_name: ${PROJECT_NAME}-restapi
     build:
@@ -133,10 +141,12 @@ services:
     networks:
       openimis-net:
          ipv4_address: 172.20.${IP_SUB:-20}.17
+
 volumes:
   database:
   logs:
   photos:
+
 networks:
   openimis-net:
     name: ${PROJECT_NAME}-openimis-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,12 @@ services:
       retries: 5
       start_period: 30s
     volumes:
-
       - database:/var/lib/postgresql/data
     restart: always
     networks:
       openimis-net:
         ipv4_address: 172.20.${IP_SUB:-20}.99
+
   backend:
     container_name: ${PROJECT_NAME:-openimis}-backend
     build:
@@ -41,10 +41,13 @@ services:
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_ENGINE=${DB_ENGINE:-django.db.backends.postgresql}
-      - SITE_ROOT=api
+      - SITE_ROOT=${SITE_ROOT:-api}
       - SITE_URL=${NEW_OPENIMIS_HOST}
       - CELERY_BROKER_URL=amqp://rabbitmq
       - PHOTO_ROOT_PATH=images/insurees
+      - DJANGO_LOG_LEVEL=${DJANGO_LOG_LEVEL}
+      - DJANGO_LOG_HANDLER=${DJANGO_LOG_HANDLER}
+      - DJANGO_MIGRATE=${DJANGO_MIGRATE}
     depends_on:
       db:
         condition: service_healthy
@@ -62,7 +65,7 @@ services:
     command: serve -s build
     environment:
       - PORT=5000
-      - REACT_APP_API_URL=/api
+      - REACT_APP_API_URL=${SITE_ROOT:-api}
       - PUBLIC_URL=/front
       - NEW_OPENIMIS_HOST=${NEW_OPENIMIS_HOST}
       - OPENIMIS_CONF_JSON=${OPENIMIS_FE_CONF_JSON}
@@ -70,6 +73,7 @@ services:
     networks:
       openimis-net:
         ipv4_address: 172.20.${IP_SUB:-20}.13
+
   gateway:
     container_name: ${PROJECT_NAME:-openimis}-gateway
     build:
@@ -93,6 +97,7 @@ services:
     depends_on:
       - backend
       - frontend
+
   worker:
     container_name: ${PROJECT_NAME:-openimis}-worker
     image: openimis/backend:${PROJECT_NAME:-local}
@@ -106,6 +111,7 @@ services:
     networks:
       openimis-net:
          ipv4_address: 172.20.${IP_SUB:-20}.15
+
   rabbitmq:
     container_name: ${PROJECT_NAME:-openimis}-rabbitmq
     image: rabbitmq:3-management
@@ -113,8 +119,9 @@ services:
     networks:
       openimis-net:
          ipv4_address: 172.20.${IP_SUB:-20}.16
+
   restapi:
-    container_name: ${PROJECT_NAME}-restapi
+    container_name: ${PROJECT_NAME:-openimis}-restapi
     build:
       context:  https://github.com/openimis/rest_api_c-sharp.git#${RESTAPI_BRANCH:-develop}
       args:
@@ -130,12 +137,14 @@ services:
     networks:
       openimis-net:
          ipv4_address: 172.20.${IP_SUB:-20}.17
+
 volumes:
   database:
   photos:
+
 networks:
   openimis-net:
-    name: ${PROJECT_NAME}-openimis-net
+    name: ${PROJECT_NAME:-openimis}-net
     ipam:
       config:
         - subnet: 172.20.${IP_SUB:-20}.0/24


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OTC-748](https://openimis.atlassian.net/browse/OTC-748)

Changes:
- Added an option to override the `/api` site root of the openIMIS backend with `SITE_ROOT` env variable, forwarded to frontend as  `REACT_APP_API_URL`
- Added missing env variables to `.env.example`