### PR TITLE
Update .env example to point to develop branch by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,11 +32,11 @@ SITE_ROOT=api
 
 # github branches to use
 # Database, you can use develop branch too
-DB_TAG=24.04
+DB_TAG=develop
 # BE assembly image tag
-BE_TAG=24.04
+BE_TAG=develop
 #FE assembly, image tag
-FE_TAG=24.04
+FE_TAG=develop
 
 #one-liner json config for the FE (to override the openimis.json from the FE assembly)
 #OPENIMIS_FE_CONF_JSON=


### PR DESCRIPTION
Since it's an example .env file, it should work out of the box with minimal modification for development environment setup. Current 24.04 tag causes error "Error response from daemon: manifest unknown" when executing `docker-compose up -d` due to unknown tag.