### PR TITLE
OS-102: added to nginx dh param file generated on fe dockerfile level

### DIFF
--- a/conf/nginx/openimis.conf
+++ b/conf/nginx/openimis.conf
@@ -12,6 +12,17 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/${NEW_OPENIMIS_HOST}/privkey.pem;
     root /usr/share/nginx/html;
 
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256";
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    # Include the generated DH parameters
+    ssl_dhparam /etc/nginx/dhparam.pem;
+
     location /.well-known {
             root /var/www/html;
     }


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OS-102

DH params generation will be added to the Dockerfile. And will be used as a part of nginx config. 

I run my local openIMIS through dockerized build. Here there is a proof that it should work (local frontend container):
![Screenshot from 2025-03-14 13-18-00](https://github.com/user-attachments/assets/da6ae495-770f-49cd-992d-ae31df5b8778)
and the file is found in the expected path (local frontend container):
![Screenshot from 2025-03-14 13-17-35](https://github.com/user-attachments/assets/b9f0ecf2-3d6a-4ad4-9045-21980b49370c)

Related PR: 
https://github.com/openimis/openimis-fe_js/pull/161