### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,11 +34,11 @@ SITE_ROOT=api
 
 # github branches to use
 # Database, you can use develop branch too
-DB_TAG=24.10
+DB_TAG=25.04
 # BE assembly image tag
-BE_TAG=24.10
+BE_TAG=25.04
 #FE assembly, image tag
-FE_TAG=24.10
+FE_TAG=25.04
 
 #one-liner json config for the FE (to override the openimis.json from the FE assembly)
 #OPENIMIS_FE_CONF_JSON=
@@ -53,3 +53,5 @@ DJANGO_LOG_HANDLER=debug-log
 DJANGO_MIGRATE=True
 
 CSRF_TRUSTED_ORIGINS=http://localhost
+# should define a strong key for JWT token key
+SECRET_KEY=


### PR DESCRIPTION
Fix openIMIS default version.

Add Secret_key parameter in .env required by graphql_jwt. Empty key will raise error on backend launching :
"django.core.exceptions.ImproperlyConfigured: The SECRET_KEY setting must not be empty."