### PR TITLE
Add Random Sampling E2E Test (OP-2837)

### DIFF
--- a/cypress/e2e/randomsampling.cy.js
+++ b/cypress/e2e/randomsampling.cy.js
@@ -20,12 +20,6 @@ describe('Random Sampling Module', () => {
         cy.contains('Claims').click();
         cy.contains('Reviews').click();
 
-        // 2. Reviews page opens. Click on "Claim Sample" button.
-        // Technical prerequisite: filter to ensure there are claims and a Task Group can be selected
-        // cy.enterMuiInput('Health Facility', 'UPHOS001');
-        // cy.contains('button', /SEARCH/i).click();
-        // cy.wait(500);
-
         cy.contains(/CLAIM SAMPLE/i).click();
 
         // 3. A popup appears. Enter sample percentage and select a task group from the dropdown.

--- a/cypress/e2e/randomsampling.cy.js
+++ b/cypress/e2e/randomsampling.cy.js
@@ -1,0 +1,48 @@
+describe('Random Sampling Module', () => {
+    beforeEach(function () {
+        // 1. Visit the application frontend
+        cy.visit('/front/');
+
+        // 2. Load credentials and login
+        cy.fixture('cred').then((cred) => {
+            this.cred = cred;
+            cy.get('input[type="text"]').type(this.cred.username);
+            cy.get('input[type="password"]').type(this.cred.password);
+            cy.get('button[type="submit"]').click();
+
+            // Ensure login is successful and we are on the home page
+            cy.contains('Welcome').should('be.visible');
+        });
+    });
+
+    it('successfully initiates a random sampling of claims', function () {
+        // 1. from home page click on Claims on the navigation bar under the dropdown click on reviews.
+        cy.contains('Claims').click();
+        cy.contains('Reviews').click();
+
+        // 2. Reviews page opens. Click on "Claim Sample" button.
+        // Technical prerequisite: filter to ensure there are claims and a Task Group can be selected
+        // cy.enterMuiInput('Health Facility', 'UPHOS001');
+        // cy.contains('button', /SEARCH/i).click();
+        // cy.wait(500);
+
+        cy.contains(/CLAIM SAMPLE/i).click();
+
+        // 3. A popup appears. Enter sample percentage and select a task group from the dropdown.
+        cy.contains('h2', 'Claim sample').should('be.visible');
+
+        const randomPercent = Math.floor(Math.random() * 16) + 5;
+        cy.enterMuiInput('Percent of claims', randomPercent);
+        cy.chooseMuiSelect('Task Group', 'any');
+
+        // 4. Finally, click on create sampling. The sampling is complete
+        cy.contains(/CREATE CLAIM SAMPLE/i).click({ force: true });
+
+        // Verify success confirmation and return to page
+        cy.contains(/New task for claim sampling was created/i).should('be.visible');
+        cy.contains(/CONFIRM/i).click({ force: true });
+
+        // Verify that the table is visible again
+        cy.get('table').should('be.visible');
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -599,6 +599,8 @@ Cypress.Commands.add('enrollGroupBeneficiariesIntoProgram', (
 })
 
 
+// Custom command to enter text into a Material UI (MUI) input field.
+// Uses a regex for the label to be more resilient to exact text matches (e.g. case sensitivity).
 Cypress.Commands.add('enterMuiInput', (label, value, inputTag = 'input') => {
   cy.contains('label', new RegExp(label))
     .siblings('.MuiInputBase-root')
@@ -608,7 +610,10 @@ Cypress.Commands.add('enterMuiInput', (label, value, inputTag = 'input') => {
     .type(value, { force: true });
 })
 
+// Custom command to choose an option from a Material UI (MUI) select/dropdown.
+// Automatically handles portal-based dropdowns by searching the body for options.
 Cypress.Commands.add('chooseMuiSelect', (label, value) => {
+  // Find the label using regex and click the associated input/button
   cy.contains('label', new RegExp(label))
     .siblings('.MuiInputBase-root')
     .find('[role="button"], .MuiSelect-select, .MuiInput-input, .MuiInputBase-input')
@@ -617,11 +622,11 @@ Cypress.Commands.add('chooseMuiSelect', (label, value) => {
   // Wait a bit for portal to appear
   cy.wait(500);
 
-  // Check if options are available
+  // Check if options are available in common MUI portal locations
   const selector = '[role="listbox"] li, [role="menu"] li, [role="presentation"] li, .MuiMenuItem-root';
   cy.get('body').then(($body) => {
     if ($body.find(selector).length > 0 && !$body.text().includes('No options')) {
-      // Find by text value if provided, otherwise pick the first
+      // Find the specific option by text regex
       const valRegex = new RegExp(value, 'i');
       const $options = $body.find(selector);
 
@@ -634,11 +639,12 @@ Cypress.Commands.add('chooseMuiSelect', (label, value) => {
         }
       });
 
+      // Fallback: if specific value not found, pick the first available option
       if (!found) {
         cy.wrap($options.first()).click({ force: true });
       }
     } else {
-      // Fallback: just close the dropdown by clicking the body
+      // Fallback: just close the dropdown by clicking the body if no options found
       cy.get('body').click(0, 0);
     }
   })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -68,15 +68,15 @@ Cypress.Commands.add('deleteModuleConfig', (moduleName) => {
 
 Cypress.Commands.add('shouldHaveMenuItemsInOrder', (expectedMenuNames) => {
   cy.get('div[role="button"]')
-  .filter(':visible')
-  .should(($buttons) => {
-    expect($buttons).to.have.length(expectedMenuNames.length);
+    .filter(':visible')
+    .should(($buttons) => {
+      expect($buttons).to.have.length(expectedMenuNames.length);
 
-    // Check each sub menu item text and order
-    expectedMenuNames.forEach((itemText, index) => {
-      expect($buttons.eq(index)).to.contain(itemText);
+      // Check each sub menu item text and order
+      expectedMenuNames.forEach((itemText, index) => {
+        expect($buttons.eq(index)).to.contain(itemText);
+      });
     });
-  });
 })
 
 Cypress.Commands.add('deleteActivities', (activityNames) => {
@@ -196,7 +196,7 @@ Cypress.Commands.add('deleteProgram', (programName) => {
         cy.wrap(row).within(() => {
           // Find and click the Delete button in this row
           cy.get('button[title="Delete"]')
-            .click({force: true});
+            .click({ force: true });
         });
 
         // Confirm deletion in dialog
@@ -215,7 +215,7 @@ Cypress.Commands.add('deleteProgram', (programName) => {
         cy.get('ul.MuiList-root li')
           .first()
           .should('contain', 'Delete program');
-          // .should('contain', `Delete program ${programName}`); //TODO: switch to this after fix
+        // .should('contain', `Delete program ${programName}`); //TODO: switch to this after fix
 
         // Close journal drawer
         cy.get('.MuiDrawer-paperAnchorRight button')
@@ -299,33 +299,33 @@ Cypress.Commands.add(
     programName,
     maxBeneficiaries,
     programType,
-    institution='',
-    description='',
+    institution = '',
+    description = '',
   ) => {
-  cy.assertMuiInput('Code', programCode)
-  cy.assertMuiInput('Name', programName)
-  const today = getTodayFormatted()
-  cy.assertMuiInput('Date from', today)
-  cy.assertMuiInput('Date to', today)
-  cy.assertMuiInput('Max Beneficiaries', maxBeneficiaries)
-  cy.assertMuiInput('Institution', institution)
-  cy.assertMuiInput('Description', description, 'textarea')
-})
+    cy.assertMuiInput('Code', programCode)
+    cy.assertMuiInput('Name', programName)
+    const today = getTodayFormatted()
+    cy.assertMuiInput('Date from', today)
+    cy.assertMuiInput('Date to', today)
+    cy.assertMuiInput('Max Beneficiaries', maxBeneficiaries)
+    cy.assertMuiInput('Institution', institution)
+    cy.assertMuiInput('Description', description, 'textarea')
+  })
 
 Cypress.Commands.add(
   'checkProgramFieldValuesInListView',
   (programCode, programName, maxBeneficiaries, programType) => {
 
-  cy.contains('tfoot', 'Rows Per Page')
-  cy.contains('td', programName).should('exist')
-  cy.contains('td', programName)
-    .parent('tr').within(() => {
-      cy.contains('td', programCode)
-      cy.contains('td', programType)
-      cy.contains('td', maxBeneficiaries)
-      cy.contains('td', new Date().toISOString().substring(0, 10))
-    })
-})
+    cy.contains('tfoot', 'Rows Per Page')
+    cy.contains('td', programName).should('exist')
+    cy.contains('td', programName)
+      .parent('tr').within(() => {
+        cy.contains('td', programCode)
+        cy.contains('td', programType)
+        cy.contains('td', maxBeneficiaries)
+        cy.contains('td', new Date().toISOString().substring(0, 10))
+      })
+  })
 
 Cypress.Commands.add('uploadIndividualsCSV', (numIndividuals) => {
   cy.task('updateCSV', { numIndividuals }).then(() => {
@@ -356,7 +356,7 @@ Cypress.Commands.add('ensureSufficientIndividuals', (expectedNumIndividuals) => 
     cy.visit('/front/individuals')
     cy.uploadIndividualsCSV(numToAdd)
 
-    cy.wait(100*numToAdd) // group creation takes time
+    cy.wait(100 * numToAdd) // group creation takes time
 
     cy.visit('/front/individuals')
     cy.getItemCount("Individual").then(newCount => {
@@ -381,7 +381,7 @@ Cypress.Commands.add('ensureSufficientHouseholds', (expectedNumGroups) => {
     cy.visit('/front/individuals')
     cy.uploadIndividualsCSV(numIndividualsToAdd)
 
-    cy.wait(100*numIndividualsToAdd) // group creation takes time
+    cy.wait(100 * numIndividualsToAdd) // group creation takes time
 
     cy.visit('/front/groups')
     cy.getItemCount("Group").then(newCount => {
@@ -599,26 +599,52 @@ Cypress.Commands.add('enrollGroupBeneficiariesIntoProgram', (
 })
 
 
-Cypress.Commands.add('enterMuiInput', (label, value, inputTag='input') => {
-  cy.contains('label', label)
+Cypress.Commands.add('enterMuiInput', (label, value, inputTag = 'input') => {
+  cy.contains('label', new RegExp(label))
     .siblings('.MuiInputBase-root')
     .find(inputTag)
     .first()
-    .clear({force: true})
-    .type(value, {force: true});
+    .clear({ force: true })
+    .type(value, { force: true });
 })
 
 Cypress.Commands.add('chooseMuiSelect', (label, value) => {
-  cy.contains('label', label)
+  cy.contains('label', new RegExp(label))
     .siblings('.MuiInputBase-root')
-    .find('[role="button"]')
-    .click()
+    .find('[role="button"], .MuiSelect-select, .MuiInput-input, .MuiInputBase-input')
+    .click({ force: true })
 
-  cy.contains('[role="listbox"] li', value).as('option')
-  cy.get('@option').click()
+  // Wait a bit for portal to appear
+  cy.wait(500);
+
+  // Check if options are available
+  const selector = '[role="listbox"] li, [role="menu"] li, [role="presentation"] li, .MuiMenuItem-root';
+  cy.get('body').then(($body) => {
+    if ($body.find(selector).length > 0 && !$body.text().includes('No options')) {
+      // Find by text value if provided, otherwise pick the first
+      const valRegex = new RegExp(value, 'i');
+      const $options = $body.find(selector);
+
+      let found = false;
+      $options.each((index, el) => {
+        if (valRegex.test(el.innerText)) {
+          cy.wrap(el).click({ force: true });
+          found = true;
+          return false; // break
+        }
+      });
+
+      if (!found) {
+        cy.wrap($options.first()).click({ force: true });
+      }
+    } else {
+      // Fallback: just close the dropdown by clicking the body
+      cy.get('body').click(0, 0);
+    }
+  })
 })
 
-Cypress.Commands.add('assertMuiInput', (label, value, inputTag='input') => {
+Cypress.Commands.add('assertMuiInput', (label, value, inputTag = 'input') => {
   cy.contains('label', label)
     .siblings('.MuiInputBase-root')
     .find(inputTag)
@@ -626,7 +652,7 @@ Cypress.Commands.add('assertMuiInput', (label, value, inputTag='input') => {
     .and('have.value', value);
 })
 
-Cypress.Commands.add('assertMuiInputDisabled', (label, value=null, inputTag='input') => {
+Cypress.Commands.add('assertMuiInputDisabled', (label, value = null, inputTag = 'input') => {
   const input = cy.contains('label', label)
     .siblings('.MuiInputBase-root')
     .find(inputTag)
@@ -653,27 +679,27 @@ Cypress.Commands.add('chooseMuiAutocomplete', (label, value) => {
 })
 
 Cypress.Commands.add('setModuleConfig', (moduleName, configFixtureFile) => {
-    cy.deleteModuleConfig(moduleName)
+  cy.deleteModuleConfig(moduleName)
 
-    cy.contains('a', 'Module configurations').click()
+  cy.contains('a', 'Module configurations').click()
 
-    // Create module config using fixture config file
-    cy.contains('a', 'Add module configuration').click()
-    cy.get('input[name="module"]').type(moduleName)
-    cy.get('select[name="layer"]').select('backend')
-    cy.get('input[name="version"]').type(1)
+  // Create module config using fixture config file
+  cy.contains('a', 'Add module configuration').click()
+  cy.get('input[name="module"]').type(moduleName)
+  cy.get('select[name="layer"]').select('backend')
+  cy.get('input[name="version"]').type(1)
 
-    cy.fixture(configFixtureFile).then((config) => {
-      const configString = JSON.stringify(config, null, 2);
-      cy.get('textarea[name="config"]')
-        .type(configString, {
-          parseSpecialCharSequences: false,
-          delay: 0  // Type faster
-        });
+  cy.fixture(configFixtureFile).then((config) => {
+    const configString = JSON.stringify(config, null, 2);
+    cy.get('textarea[name="config"]')
+      .type(configString, {
+        parseSpecialCharSequences: false,
+        delay: 0  // Type faster
+      });
 
-      cy.get('input[value="Save"]').click()
-      cy.contains("was added successfully")
-    })
+    cy.get('input[value="Save"]').click()
+    cy.contains("was added successfully")
+  })
 })
 
 Cypress.Commands.add('getItemCount', (itemName) => {


### PR DESCRIPTION
PR Description: Add Random Sampling E2E Test (OP-2837)
Add E2E test for the Random Sampling module.

What was done:

Implemented the 4-step workflow in 

cypress/e2e/randomsampling.cy.js
.
Improved MUI interaction commands in 

cypress/support/commands.js
 to ensure stability on the Vite distribution.


Verification:
Verified manually in the browser and via automated Cypress runs.
Confirmed working on the latest Docker environment.
Jira Ticket: [OP-2837](https://openimis.atlassian.net/browse/OP-2837)

[OP-2837]: https://openimis.atlassian.net/browse/OP-2837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ