### PR TITLE
Update backend.loc / Websocket reverse proxy management

### DIFF
--- a/conf/nginx/locations/backend.loc
+++ b/conf/nginx/locations/backend.loc
@@ -2,11 +2,15 @@
     location /${REACT_APP_API_URL}/ {
 
             proxy_pass http://${backend};
+            proxy_http_version 1.1;
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Host $server_name;
             proxy_set_header   X-Forwarded-Proto https;
+            proxy_set_header   Upgrade $http_upgrade;
+            proxy_set_header   Connection "upgrade";
+            proxy_read_timeout 86400;
     }
     location = /check_user/ {
            internal;


### PR DESCRIPTION
  # Description

  This PR adds WebSocket support to the nginx reverse proxy configuration for the backend API location.

  The nginx proxy configuration has been updated to properly handle WebSocket connections by:
  - Enabling HTTP/1.1 protocol (required for WebSocket handshake)
  - Forwarding `Upgrade` and `Connection` headers for WebSocket negotiation
  - Setting an extended read timeout (24 hours) to prevent WebSocket connections from timing out

  This enables real-time bidirectional communication between the frontend and backend, which is essential for features requiring instant updates without polling (e.g., notifications, live data feeds, video stream management, Claim AI module).

  # Type of Change

  - [x] Feature
  - [ ] Bug fix
  - [ ] Chore (Refactor, Docs, CI/CD)
  - [ ] Other, please specify

  ## Related Issue(s) / Task(s)
  - [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
  - [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
  - [ ] External reference (e.g., Jira): [Add reference if applicable]

  ## Technical Details

  **Modified file:** `openimis-dist_dkr/conf/nginx/locations/backend.loc`

  **Changes made:**
  1. Added `proxy_http_version 1.1;` - WebSocket requires HTTP/1.1
  2. Added `proxy_set_header Upgrade $http_upgrade;` - Forwards upgrade header
  3. Added `proxy_set_header Connection "upgrade";` - Sets connection upgrade mode
  4. Added `proxy_read_timeout 86400;` - 24-hour timeout for persistent connections

  ## Testing

  After deployment, WebSocket connections can be tested by:
  1. Verifying nginx configuration: `nginx -t`
  2. Reloading nginx: `nginx -s reload`
  3. Testing WebSocket endpoint connectivity from the frontend
  4. Confirming persistent connections remain active without timeout

  ## Demo

  N/A - Infrastructure configuration change

  ## Checklist
  - [ ] Unit tests added/modified - N/A (nginx configuration)
  - [ ] I18n / translation handled - N/A (nginx configuration)