### PR TITLE
feat: Docker deployment wiring for ClaimGuard hackathon module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ClaimGuard — Multi-Track Explainable AI Fraud Overlay
 
+> **Technikali** — openIMIS Hackathon submission
+
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](./LICENSE.md)
 [![Track 3](https://img.shields.io/badge/Track-3%20Claims%20%26%20Fraud-2ea44f)](https://openimis.org)
 [![Track 5](https://img.shields.io/badge/Cross--Track-5%20AI%20%26%20Emerging%20Tech-6f42c1)](https://openimis.org)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,187 @@
-<center>
-<img src="https://openimis.org/themes/custom/ffw/logo.svg" width="200px" alt="openIMIS logo" />
-</center>
+# ClaimGuard — Multi-Track Explainable AI Fraud Overlay
 
-# openIMIS Distribution
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](./LICENSE.md)
+[![Track 3](https://img.shields.io/badge/Track-3%20Claims%20%26%20Fraud-2ea44f)](https://openimis.org)
+[![Track 5](https://img.shields.io/badge/Cross--Track-5%20AI%20%26%20Emerging%20Tech-6f42c1)](https://openimis.org)
+[![Track 1](https://img.shields.io/badge/Cross--Track-1%20Innovation-fb8500)](https://openimis.org)
 
-This repository provides configuration files for deploying openIMIS via Docker. This is intended to help you setup all components to quickly setup, test and evaluate the solution.
+**Track Submission:** Track 3 (Claims Management & Fraud Detection)  
+**Cross-Track Integrations:** Track 5 (AI & Emerging Tech) & Track 1 (Innovation Track)  
+**License:** [GNU AGPL v3](./LICENSE.md)
 
-Detailed instructions are in our Wiki: [Installation Guide](https://openimis.atlassian.net/wiki/spaces/OP/pages/963182705/MO1.1+Install+the+modular+openIMIS+using+Docker)
+---
 
-[![DPG Badge](https://img.shields.io/badge/Verified-DPG-3333AB?logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzEiIGhlaWdodD0iMzMiIHZpZXdCb3g9IjAgMCAzMSAzMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0LjIwMDggMjEuMzY3OEwxMC4xNzM2IDE4LjAxMjRMMTEuNTIxOSAxNi40MDAzTDEzLjk5MjggMTguNDU5TDE5LjYyNjkgMTIuMjExMUwyMS4xOTA5IDEzLjYxNkwxNC4yMDA4IDIxLjM2NzhaTTI0LjYyNDEgOS4zNTEyN0wyNC44MDcxIDMuMDcyOTdMMTguODgxIDUuMTg2NjJMMTUuMzMxNCAtMi4zMzA4MmUtMDVMMTEuNzgyMSA1LjE4NjYyTDUuODU2MDEgMy4wNzI5N0w2LjAzOTA2IDkuMzUxMjdMMCAxMS4xMTc3TDMuODQ1MjEgMTYuMDg5NUwwIDIxLjA2MTJMNi4wMzkwNiAyMi44Mjc3TDUuODU2MDEgMjkuMTA2TDExLjc4MjEgMjYuOTkyM0wxNS4zMzE0IDMyLjE3OUwxOC44ODEgMjYuOTkyM0wyNC44MDcxIDI5LjEwNkwyNC42MjQxIDIyLjgyNzdMMzAuNjYzMSAyMS4wNjEyTDI2LjgxNzYgMTYuMDg5NUwzMC42NjMxIDExLjExNzdMMjQuNjI0MSA5LjM1MTI3WiIgZmlsbD0id2hpdGUiLz4KPC9zdmc+Cg==)](https://digitalpublicgoods.net/r/openimis)
+## Problem Statement
+
+Automated fraud adjudication modules often operate as unexplainable "black boxes." When a machine learning model flags a claim as anomalous, human reviewers face alert fatigue and a lack of contextual trust, leading to system overrides that leak billions of shillings annually.
+
+## Our Solution
+
+ClaimGuard bridges the gap between pure statistical machine learning and human-centered design. By merging Track 3's processing rails with Track 5's AI capabilities, we engineered an overlay that hooks natively into openIMIS via Django signals — **without monkey-patching core workflows**.
+
+The system:
+
+- Extracts **hyper-local facility baselines** from historical Tanzania demo data
+- Translates **Isolation Forest** anomalies into plain-language, high-signal medical risk vectors
+- Surfaces results on a polished **React reviewer panel** with override workflows and audit logging
+
+---
+
+## Architecture & Data Flow
+
+```mermaid
+flowchart LR
+    A[Claim Submitted] --> B[Django post-save signal]
+    B --> C[Feature extraction]
+    C --> D[Rule engine + Isolation Forest]
+    D --> E[Risk score 0–100]
+    E --> F[FHIR ClaimResponse + json_ext sync]
+    F --> G[React reviewer dashboard]
+    G --> H[Human override + audit log]
+```
+
+| Stage | Track | What happens |
+|-------|-------|--------------|
+| **Ingestion** | 1 / 3 | Django `post_save` signals intercept claim submission seamlessly |
+| **Context extraction** | 3 | Weekly billing deviations vs. historical Tanzania demo baselines via Django ORM aggregations |
+| **XAI engine** | 5 | Features pass to an Isolation Forest model; quantitative weights map to explainable reason codes |
+| **Dashboard** | 3 / 5 | Priority queue, Financial Analytics Panel, metric alert grids, and override workflow |
+
+### Risk tiers
+
+| Score | Tier | Default action |
+|-------|------|----------------|
+| 0–30 | Green | Auto-approve |
+| 31–70 | Amber | Flag for review |
+| 71–100 | Red | Auto-hold |
+
+---
+
+## Repository Map
+
+This distribution wires ClaimGuard into a full openIMIS Docker stack. The hackathon submission spans these public forks:
+
+| Repository | Role |
+|------------|------|
+| [openimis-dist_dkr](https://github.com/nosh-thee-techy/openimis-dist_dkr) | Docker compose, volume mounts, frontend image build |
+| [openimis-be-claimguard_py](https://github.com/Nosh-thee-techy/openimis-be-claimguard_py) | Django module — scoring engine, GraphQL, REST API |
+| [openimis-fe-claimguard_js](https://github.com/Nosh-thee-techy/openimis-fe-claimguard_js) | React module — dashboard, XAI panel, priority queue |
+| [openimis-be_py](https://github.com/Nosh-thee-techy/openimis-be_py) | Backend assembly with `claimguard` in `openimis.json` |
+| [openimis-fe_js](https://github.com/Nosh-thee-techy/openimis-fe_js) | Frontend assembly with `@openimis/fe-claimguard` linked locally |
+
+---
+
+## Prerequisites
+
+- Docker & Docker Compose
+- Sibling clones checked out next to this repo:
+
+```
+parent/
+├── openimis-dist_dkr/          ← you are here
+├── openimis-be_py/
+├── openimis-be-claimguard_py/
+├── openimis-fe_js/
+└── openimis-fe-claimguard_js/
+```
+
+---
+
+## Installation & Setup
+
+### 1. Clone the stack
+
+```bash
+git clone https://github.com/nosh-thee-techy/openimis-dist_dkr.git
+git clone https://github.com/Nosh-thee-techy/openimis-be_py.git
+git clone https://github.com/Nosh-thee-techy/openimis-be-claimguard_py.git
+git clone https://github.com/Nosh-thee-techy/openimis-fe_js.git
+git clone https://github.com/Nosh-thee-techy/openimis-fe-claimguard_js.git
+```
+
+### 2. Configure environment
+
+```bash
+cd openimis-dist_dkr
+cp .env.example .env
+# Edit .env — set DOMAIN, DB credentials, SECRET_KEY, etc.
+```
+
+### 3. Load the Tanzania demo dataset
+
+Ensure the Tanzania demo dataset is loaded (`demo.sql`) into your database before scoring claims.
+
+### 4. Verify module registration
+
+`claimguard` must appear in `openimis-be_py/openimis.json`:
+
+```json
+{ "name": "claimguard", "pip": "-e /openimis-be/openimis-be-claimguard_py" }
+```
+
+The frontend assembly references `@openimis/fe-claimguard` via a local file link in `openimis-fe_js/openimis.json`.
+
+### 5. Start the stack
+
+```bash
+docker compose up -d
+```
+
+`compose.base.yml` mounts the ClaimGuard backend module and builds a custom frontend image (`openimis-fe:claimguard`).
+
+### 6. Migrate and train (first run)
+
+```bash
+docker compose exec backend python manage.py migrate claimguard
+docker compose exec backend python manage.py generate_synthetic --count 100
+docker compose exec backend python manage.py train_model
+```
+
+### 7. Access the UI
+
+Open your configured `DOMAIN` in a browser. Navigate to **Claims → ClaimGuard Dashboard** for the fraud analytics panel and priority review queue.
+
+---
+
+## API Surface
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/claimguard/scores/` | List scores (`?tier=red`) |
+| `GET` | `/api/claimguard/scores/<claim_id>/` | Score for one claim |
+| `POST` | `/api/claimguard/scores/<claim_id>/override/` | Auditor override with justification |
+| `GET` | `/api/claimguard/analytics/` | Dashboard summary metrics |
+
+GraphQL queries (`claimFraudScore`, `claimFraudScores`) and the `overrideClaimFraudScore` mutation are also available through the standard openIMIS GraphQL endpoint.
+
+---
+
+## Known Limitations & Future Roadmap
+
+- **Supervised retraining loops** — Future sprints will pipe human override text justifications directly back into the scikit-learn training architecture.
+- **Model drift monitoring** — Baseline recalculation is manual today; automated weekly refresh is planned.
+- **Multi-country baselines** — Current facility baselines are tuned for the Tanzania demo dataset.
+
+---
+
+## Development
+
+```bash
+# Rebuild the ClaimGuard frontend module
+cd ../openimis-fe-claimguard_js && npm run build
+
+# Run backend unit tests (inside the backend container)
+docker compose exec backend python manage.py test claimguard
+```
+
+---
+
+## Submission
+
+**Release tag:** `v1.0-hackathon`
+
+---
+
+## License
+
+ClaimGuard is released under the [GNU Affero General Public License v3](./LICENSE.md), consistent with the openIMIS ecosystem.

--- a/compose.base.yml
+++ b/compose.base.yml
@@ -34,7 +34,7 @@ services:
   frontend:
     build:
       context: ..
-      dockerfile: openimis-fe_js/Dockerfile
+      dockerfile: openimis-fe_js/Dockerfile.runtime
     image: openimis-fe:claimguard
     restart: always
     environment:

--- a/compose.base.yml
+++ b/compose.base.yml
@@ -32,7 +32,10 @@ x-api: &default-api
 
 services:
   frontend:
-    image: ghcr.io/openimis/openimis-fe:${FE_TAG:-develop}
+    build:
+      context: ..
+      dockerfile: openimis-fe_js/Dockerfile
+    image: openimis-fe:claimguard
     restart: always
     environment:
       - REACT_APP_SENTRY_DSN=${REACT_APP_SENTRY_DSN}

--- a/compose.base.yml
+++ b/compose.base.yml
@@ -19,8 +19,11 @@ x-api: &default-api
     - OPENSEARCH_ADMIN=${OPENSEARCH_ADMIN}
     - OPENSEARCH_PASSWORD=${OPENSEARCH_PASSWORD}
     - OPENSEARCH_HOSTS=${OPENSEARCH_HOSTS}
+    - PYTHONPATH=/openimis-be/openimis-be-claimguard_py
   volumes:
     - photos:/openimis-be/openIMIS/images/insurees
+    - ../openimis-be-claimguard_py:/openimis-be/openimis-be-claimguard_py
+    - ../openimis-be_py/openimis.json:/openimis-be/openimis.json
   depends_on:
     db:
       condition: service_healthy


### PR DESCRIPTION
# Thank you for your contribution to openIMIS!

## Description

Adds Docker Compose configuration to run ClaimGuard alongside a standard openIMIS stack. This is the **recommended way to evaluate** the hackathon submission end-to-end.

Includes an updated root README with architecture, setup steps, API surface, and links to all ClaimGuard repos.

## Related repositories (submission tag: `v1.0-hackathon`)

- Backend module: https://github.com/Nosh-thee-techy/openimis-be-claimguard_py
- Frontend module: https://github.com/Nosh-thee-techy/openimis-fe-claimguard_js
- Backend assembly: https://github.com/Nosh-thee-techy/openimis-be_py (PR #___)
- Frontend assembly: https://github.com/Nosh-thee-techy/openimis-fe_js (PR #___)

## What changed

- `compose.base.yml` — volume-mounts `openimis-be-claimguard_py`, custom `openimis.json`, builds `openimis-fe:claimguard` image
- `README.md` — ClaimGuard hackathon documentation (problem, architecture, install, API, limitations)

## How to test

```bash
git clone https://github.com/Nosh-thee-techy/openimis-dist_dkr.git
# clone sibling repos (be_py, be-claimguard_py, fe_js, fe-claimguard_js)
cp .env.example .env   # configure DOMAIN, DB, etc.
docker compose up -d
docker compose exec backend python manage.py migrate claimguard
docker compose exec backend python manage.py train_model