### PR TITLE
fix: remove duplicate environment variable entries in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,8 +48,6 @@ FE_TAG=25.10
 
 #one-liner json config for the FE (to override the openimis.json from the FE assembly)
 #OPENIMIS_FE_CONF_JSON=
-#one-liner json config for the FE (to overright the openimis.json from the FE assembly)
-#OPENIMIS_FE_CONF_JSON=
 
 # django log level
 DJANGO_LOG_LEVEL=WARNING
@@ -58,9 +56,6 @@ DJANGO_LOG_HANDLER=debug-log
 # should the database be migrated at every container startup. Will be done anyway if $SITE_ROOT=api
 DJANGO_MIGRATE=True
 
-CSRF_TRUSTED_ORIGINS=http://localhost
-# should define a strong key for JWT token key
-SECRET_KEY=
 # set your sentry DSN here
 REACT_APP_SENTRY_DSN=""
 
@@ -95,7 +90,7 @@ REDIS_PASSWORD=redisUserPass123
 CACHE_URL=redis://:${REDIS_PASSWORD}@redis:6379
 
 ## Cache Options
-## See: https://
+## See: https://docs.djangoproject.com/en/stable/topics/cache/
 CACHE_OPTIONS={}
 
 ## Whether to cache objects by default


### PR DESCRIPTION
- Remove duplicate CSRF_TRUSTED_ORIGINS entry (was on line 8 and 61)
- Remove duplicate SECRET_KEY entry (was on line 12 and 63)
- Remove duplicate OPENIMIS_FE_CONF_JSON entry (was on line 49-50 and 51-52)

This prevents user confusion during setup and ensures a clean configuration template.

#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

A clear, concise description of the change. Why is it needed? What problem does it solve?

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
