### PR TITLE
fix: authorize OpenSearch Dashboards against openIMIS rights and stop shipping a credential

### DIFF
--- a/.env.openSearch.example
+++ b/.env.openSearch.example
@@ -3,11 +3,19 @@ CLUSTER_NAME=my_opensearch_cluster
 OPEN_SEARCH_HTTP_PORT=9200
 SLL_HTTP_ENABLED=false
 OPENSEARCH_ADMIN=admin
-# it needs a special character, in that example the 'Y' in not a 'Y' but a special character, wihtout it opensearch won't start
-OPENSEARCH_PASSWORD=B9wc9VrqX7pY
+# Unused while the security plugin is disabled, which is the default: the
+# cluster accepts anything and no admin password is configured. Never commit
+# a value.
+OPENSEARCH_PASSWORD=
 OPENSEARCH_DSL_AUTOSYNC=True
 OPENSEARCH_HOST=opensearch
-# generate basic token
-# echo -n '{OPENSEARCH_ADMIN}:{OPENSEARCH_PASSWORD}' | base64
-OPENSEARCH_BASIC_TOKEN=Basic YWRtaW46Qjl3YzlWcnFYN3BZ
+# Sent upstream by the /opensearch/ proxy; only needed when the cluster
+# requires basic auth, leave empty otherwise. Bare base64, no "Basic " prefix:
+# echo -n "${OPENSEARCH_ADMIN}:${OPENSEARCH_PASSWORD}" | base64
+OPENSEARCH_BASIC_TOKEN=
 OPENSEARCH_HOSTS='["http://opensearch:9200"]'
+# Set both false to run the cluster with the security plugin enabled.
+# OPENSEARCH_PASSWORD then has to be strong: the demo installer rejects an
+# empty or weak one.
+OPENSEARCH_SECURITY_DISABLED=true
+OPENSEARCH_DISABLE_DEMO_CONFIG=true

--- a/.env.openSearch.example
+++ b/.env.openSearch.example
@@ -1,6 +1,5 @@
 DISCOVERY_TYPE=single-node
 CLUSTER_NAME=my_opensearch_cluster
-OPEN_SEARCH_HTTP_PORT=9200
 SLL_HTTP_ENABLED=false
 OPENSEARCH_ADMIN=admin
 # Unused while the security plugin is disabled, which is the default: the
@@ -8,12 +7,13 @@ OPENSEARCH_ADMIN=admin
 # a value.
 OPENSEARCH_PASSWORD=
 OPENSEARCH_DSL_AUTOSYNC=True
-OPENSEARCH_HOST=opensearch
+# The backend's connection, as host:port. Dashboards' JSON-array form is set
+# in compose.openSearch.yml - the two formats are not interchangeable.
+OPENSEARCH_HOSTS=opensearch:9200
 # Sent upstream by the /opensearch/ proxy; only needed when the cluster
 # requires basic auth, leave empty otherwise. Bare base64, no "Basic " prefix:
 # echo -n "${OPENSEARCH_ADMIN}:${OPENSEARCH_PASSWORD}" | base64
 OPENSEARCH_BASIC_TOKEN=
-OPENSEARCH_HOSTS='["http://opensearch:9200"]'
 # Set both false to run the cluster with the security plugin enabled.
 # OPENSEARCH_PASSWORD then has to be strong: the demo installer rejects an
 # empty or weak one.

--- a/CONTRIBUTOR.md
+++ b/CONTRIBUTOR.md
@@ -35,19 +35,18 @@ If the implementation involves managing the social protection workflow/import, t
 
 ## OpenSearch/OpenSearch Dashboards setup 
 
-Both OpenSearch and OpenSearch Dashboards are not by default enabled in dockerized instance. To make them work, it's required to: 
+OpenSearch and OpenSearch Dashboards ship in `compose.openSearch.yml`, which `compose.yml` includes - `docker compose up -d` starts them with everything else. Neither service publishes a host port: the only route to Dashboards is the frontend nginx at `/opensearch/`, which authorizes every request against the openIMIS dashboards right (`opensearch_reports/auth_check`) and redirects anonymous users to the login page.
 
-  * Copy `.env.openSearch.example` to `.env.openSearch` and make adjustments
-  * Run container build `docker compose -f docker-compose.yml -f docker-compose.openSearch.yml build opensearch opensearch-dashboards nginx`
-  * Run service `docker compose -f docker-compose.yml -f docker-compose.openSearch.yml up opensearch opensearch-dashboards nginx`
+  * Copy `.env.openSearch.example` to `.env.openSearch` and adjust if needed. The defaults run the cluster with the security plugin disabled and no admin credential configured anywhere; to enable the plugin set `OPENSEARCH_SECURITY_DISABLED=false`, `OPENSEARCH_DISABLE_DEMO_CONFIG=false` and a strong `OPENSEARCH_PASSWORD`.
+  * `OPENSEARCH_BASIC_TOKEN` is only needed when the cluster requires basic auth; leave it empty otherwise. Bare base64: `echo -n "admin:<password>" | base64`.
 
-This build provides also additional nginx proxy server in order to handle OpenSearch Dashboard application on frontend level. 
+Verify the gate once the stack is up:
 
-To run on a dockerized instance of openIMIS (database, backend, and frontend), including OpenSearch, please follow the steps below:
+```
+curl -so /dev/null -w '%{http_code}\n' http://localhost/opensearch/app/home   # 302 -> login
+```
 
-  * Add a value for the OPENSEARCH_BASIC_TOKEN in the environment (`.env`) file. This should be based on the admin and password credentials for OpenSearch.
-  * In the `.env` file in openimis-fe_js, use the following environment variable: `ENV OPENSEARCH_PROXY_ROOT="opensearch"`.
-  * Run the backend and frontend services.
+A logged-in user holding the dashboards right gets 200; without the right, 403.
 
 ## Run openIMIS with Docker
 

--- a/compose.openSearch.yml
+++ b/compose.openSearch.yml
@@ -9,7 +9,10 @@ services:
       - "cluster.name=${CLUSTER_NAME:-my_opensearch_local}"
       - "http.port=${OPEN_SEARCH_HTTP_PORT:-9200}"
       - "plugins.security.ssl.http.enabled=${SLL_HTTP_ENABLED:-false}"
-      - "plugins.security.disabled=true"
+      - "plugins.security.disabled=${OPENSEARCH_SECURITY_DISABLED:-true}"
+      # The demo installer runs before the node reads plugins.security.disabled
+      # and aborts on an empty password. Set false when enabling security.
+      - "DISABLE_INSTALL_DEMO_CONFIG=${OPENSEARCH_DISABLE_DEMO_CONFIG:-true}"
       - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_PASSWORD}"
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:9200/_cluster/health || exit 1"]
@@ -26,7 +29,8 @@ services:
     image: opensearchproject/opensearch-dashboards:2.9.0
     environment:
       - OPENSEARCH_HOSTS=${OPENSEARCH_HOSTS:-http://opensearch:9200}
-      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
+      # Tracks the node: the plugin must be off here too when it is off there.
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=${OPENSEARCH_SECURITY_DISABLED:-true}"
       - SERVER_BASEPATH=/opensearch
       - SERVER_REWRITEBASEPATH=true
     volumes:

--- a/compose.openSearch.yml
+++ b/compose.openSearch.yml
@@ -1,13 +1,13 @@
 services:
 
   opensearch:
-    image: opensearchproject/opensearch:latest
+    image: opensearchproject/opensearch:3.8.0
     env_file:
       - ".env.openSearch"
     environment:
       - "discovery.type=${DISCOVERY_TYPE:-single-node}"
       - "cluster.name=${CLUSTER_NAME:-my_opensearch_local}"
-      - "http.port=${OPEN_SEARCH_HTTP_PORT:-9200}"
+      - "http.port=9200"
       - "plugins.security.ssl.http.enabled=${SLL_HTTP_ENABLED:-false}"
       - "plugins.security.disabled=${OPENSEARCH_SECURITY_DISABLED:-true}"
       # The demo installer runs before the node reads plugins.security.disabled
@@ -26,23 +26,17 @@ services:
       openimis-net:
 
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:2.9.0
+    image: opensearchproject/opensearch-dashboards:3.8.0
     environment:
-      - OPENSEARCH_HOSTS=${OPENSEARCH_HOSTS:-http://opensearch:9200}
+      # Dashboards needs the JSON-array form; the backend's OPENSEARCH_HOSTS in
+      # .env.openSearch is host:port. The two are not interchangeable.
+      - 'OPENSEARCH_HOSTS=["http://opensearch:9200"]'
       # Tracks the node: the plugin must be off here too when it is off there.
       - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=${OPENSEARCH_SECURITY_DISABLED:-true}"
       - SERVER_BASEPATH=/opensearch
       - SERVER_REWRITEBASEPATH=true
-    volumes:
-      - "./conf/opensearch/opensearch.yml:/usr/share/opensearch-dashboards/config/opensearch.yml"
     networks:
       openimis-net:
 
 volumes:
   opensearch-data1:
-
-# networks:
-#   openimis-net:
-#     name: "${PROJECT_NAME:-openimis}-net"
-#     external: true
-

--- a/conf/nginx/locations/opensearch.loc
+++ b/conf/nginx/locations/opensearch.loc
@@ -1,6 +1,21 @@
 
+    # Authorizes Dashboards against openIMIS rights, not merely a valid session.
+    # 200 right held, 403 right missing, 401 no session -> login.
+    location = /check_opensearch/ {
+        internal;
+        proxy_pass http://${backend}/${REACT_APP_API_URL}/opensearch_reports/auth_check;
+        proxy_method GET;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Original-URI $request_uri;
+    }
+
     location /opensearch/ {
-        auth_request /check_user/;
+        auth_request /check_opensearch/;
+        # auth_request can only deny; 403 passes through unchanged.
+        error_page 401 = @openimis_login;
+
         proxy_pass http://${opensearch};
         proxy_set_header   Host $host;
         proxy_set_header   X-Real-IP $remote_addr;
@@ -8,6 +23,9 @@
         proxy_set_header   X-Forwarded-Proto https;
         proxy_set_header   X-Forwarded-Host $server_name;
         proxy_set_header Authorization "Basic ${OPENSEARCH_BASIC_TOKEN}";
-    
+
     }
 
+    location @openimis_login {
+        return 302 /${PUBLIC_URL}/login;
+    }


### PR DESCRIPTION
Follow-up to openimis/openimis-be_py#386, as requested there: *"isolated net + no pass + proxy that enforce credential : OK for me, can you update dist_dkr so I can test?"* This ports the same posture to the deployment compose — which needs it independently, because this repo mounts its own `conf/nginx` over the frontend image's, so the gate from openimis/openimis-fe_js#232 never reaches a dist_dkr deployment.

## Change

- **Gate `/opensearch/` on the openIMIS dashboards right.** `conf/nginx/locations/opensearch.loc` still ran `auth_request /check_user/`, which checks authentication only — any logged-in user could read every index, including personal data. It now calls `opensearch_reports/auth_check` (openimis/openimis-be-opensearch_reports_py#29), byte-identical to the config in openimis/openimis-fe_js#232: 200 with the right, 403 without, anonymous 302 → login.
- **Stop shipping the OpenSearch credential.** `.env.openSearch.example` carried the GitGuardian-flagged password and its Base64 basic token (incident 16640553). Both are now empty; the security plugin is off by default so nothing needs them. The old "special character" comment was wrong — the node fails on an *empty* `OPENSEARCH_INITIAL_ADMIN_PASSWORD` because the image entrypoint runs the security demo installer before the node reads `plugins.security.disabled`. `DISABLE_INSTALL_DEMO_CONFIG=true` skips it; both switches are variables (`OPENSEARCH_SECURITY_DISABLED`, `OPENSEARCH_DISABLE_DEMO_CONFIG`), so running with the plugin enabled is an `.env` change, not a compose edit — verified: both `false` + strong password → 401 anonymous, 200 with credentials. Note the old token value also included the `Basic ` prefix that the nginx template adds itself, so deployments sent `Authorization: Basic Basic …` — it never worked as configured.
- **Pin both images to 3.8.0.** The node was unpinned (`latest`, currently 3.8.x) against Dashboards pinned 2.9.0 — a 2.x Dashboards against a 3.x node is outside the supported compatibility matrix.
- **Give the backend a parseable `OPENSEARCH_HOSTS`.** One variable fed two incompatible formats: Dashboards needs `["http://opensearch:9200"]`, Django comma-splits `host:port`. The JSON form reached the backend, where the client constructor throws `TypeError`. Dashboards' JSON form is now fixed in compose; `.env.openSearch.example` carries `opensearch:9200` for the backend.
- **Drop the broken Dashboards mount.** `./conf/opensearch/opensearch.yml` has never existed in this repo's history (checked `--all --full-history`), so the bind mount auto-created an empty directory on every `up` — at a filename Dashboards doesn't read (`opensearch_dashboards.yml` is its config). Nothing in CI, cypress, or scripts references the path. If Phase E later needs real Dashboards config (tenancy etc.), the right mount is a tracked `opensearch_dashboards.yml`.
- `http.port` is fixed at 9200: Dashboards addresses the node as `opensearch:9200`, so the old variable could only break the link. Neither service publishes a host port — unchanged; the isolated network stays the only route in, through the authorizing proxy.

## Verified

Full stack from this branch (`.env.example` defaults + `DEMO_DATASET=true`, images `25.10`), with #29's endpoint installed into the backend container:

| Case | Result |
|---|---|
| anonymous `/opensearch/app/home` | 302 → `/front/login` |
| invalid JWT cookie | 302 → `/front/login` |
| Admin (holds the right) | 200 |
| Dashboards `/opensearch/api/status` through the proxy | `"state":"green"` |
| logged-in user **without** the right (`is_imis_admin: False`) | **403** |
| direct `:5601` | connection refused — no published port |

## To test

Merge openimis/openimis-be-opensearch_reports_py#29 first — the gate calls its endpoint, and the nightly `openimis-be:develop` build picks the module up automatically. Then, with `BE_TAG=develop`: `cp` the two example env files, `docker compose up -d`, and the curl in CONTRIBUTOR.md. Until #29 is in an image, the endpoint answers 404 and the gate fails closed (nginx 500 for authenticated users).

## Note on the config duplication

Because this repo's `conf/nginx` mount overrides the frontend image's config, `opensearch.loc` exists twice: here and in openimis-fe_js. This PR re-syncs the copies (they had drifted since April 2024); any future gate change in openimis-fe_js has to be mirrored here by hand as long as the mount exists.
