### PR TITLE
chore: update docker volume for postgres container

### DIFF
--- a/compose.postgresql.yml
+++ b/compose.postgresql.yml
@@ -13,8 +13,11 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+    # Note: openIMIS used /var/lib/postgresql/data for the volume,
+    # From 26.10 the volume has been changed to reflect the need
+    # for upgrade procedures for postgres for installations
     volumes:
-      - database:/var/lib/postgresql/data
+      - database:/var/lib/postgresql/18/data
     restart: always
     networks:
       openimis-net:


### PR DESCRIPTION
# Description

Changes the default volume for postgres container to align with upgrade of postgres version to 18

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
